### PR TITLE
Separate staging deployment & testing workflows

### DIFF
--- a/.github/workflows/webclient-test-deploy.yml
+++ b/.github/workflows/webclient-test-deploy.yml
@@ -8,6 +8,7 @@ on:
       - ".github/workflows/webclient-deploy.yml"
       - ".github/workflows/webclient-setup/action.yml"
       - ".github/workflows/webclient-test.yml"
+      - ".github/workflows/webclient-test-deploy.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/webclient-test.yml
+++ b/.github/workflows/webclient-test.yml
@@ -8,6 +8,7 @@ on:
       - ".github/workflows/webclient-deploy.yml"
       - ".github/workflows/webclient-setup/action.yml"
       - ".github/workflows/webclient-test.yml"
+      - ".github/workflows/webclient-test-deploy.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Cypress needs push type workflows. If use in a pull_request workflow the test run names use the commit sha instead of readable names.

And, deploy to preview needs to use pull_request.event object which is not present in the push workflow