### PR TITLE
NFID Auth CLient fix

### DIFF
--- a/packages/web-client/src/lib/helpers/auth.ts
+++ b/packages/web-client/src/lib/helpers/auth.ts
@@ -1,5 +1,5 @@
 import Log from '$lib/utils/Log'
-import { AuthClient } from '@dfinity/auth-client'
+import { AuthClient, LocalStorage } from '@dfinity/auth-client'
 import { get } from 'svelte/store'
 import { authState, authHelper, referralId } from '$stores/auth'
 import { updateProfile } from './profile'
@@ -123,12 +123,14 @@ export async function initializeAuthClient(): Promise<{
   const authHelperData = get(authHelper)
   let client: AuthClient | undefined = undefined
   if (!authHelperData.client) {
-    client = await AuthClient.create({
-      idleOptions: {
-        disableIdle: true,
-        disableDefaultIdleCallback: true,
-      },
-    })
+      client = await AuthClient.create({
+          storage: new LocalStorage(),
+          keyType: 'Ed25519',
+          idleOptions: {
+              disableIdle: true,
+              disableDefaultIdleCallback: true,
+          },
+      })
   } else {
     client = authHelperData.client
   }


### PR DESCRIPTION
NFID wasn't expecting changes implemented in newer versions of agentjs. The net effect is users new to NFID aren't able to sign in to your application. We're proposing a temporary fix whose only change is to specify where the delegation information will be stored, and which key type to use. This won't affect new or existing II users or existing NFID users, and will enable new NFID users to create accounts with your app.